### PR TITLE
[common.configuration] remove unnecessary explicit

### DIFF
--- a/dune/xt/common/configuration.hh
+++ b/dune/xt/common/configuration.hh
@@ -58,7 +58,7 @@ class Configuration : public Dune::ParameterTree
 public:
   Configuration();
 
-  explicit Configuration(const ParameterTree& tree, ConfigurationDefaults defaults = ConfigurationDefaults());
+  Configuration(const ParameterTree& tree, ConfigurationDefaults defaults = ConfigurationDefaults());
 
   Configuration(const ParameterTree& tree_in, const std::string sub_id);
 


### PR DESCRIPTION
@renefritze, @ftalbrecht is there a reason for this ``explicit``? @chr-engwer mentioned that it might be useful to be able to pass a ``ParameterTree`` where a ``Configuration`` is expected, for example when testing several Dune solvers (which expect ``ParameterTree``s), including some from ``dune-xt`` (which expect ``Configuration``s).