### PR TITLE
Move walk_range from private to public

### DIFF
--- a/cmake/modules/DuneXtMacros.cmake
+++ b/cmake/modules/DuneXtMacros.cmake
@@ -22,7 +22,7 @@ include(Hints)
 # library checks  #########################################################################
 find_package(PkgConfig)
 
-set(DS_REQUIRED_BOOST_LIBS atomic chrono date_time filesystem system thread timer)
+set(DS_REQUIRED_BOOST_LIBS atomic chrono date_time filesystem python system thread timer)
 set(BOOST_ROOT_HINTS "$ENV{BOOST_ROOT}" ${root_hints})
 # FindBoost can only take a single hint directory from BOOST_ROOT, so we loop over all hints
 foreach(BOOST_ROOT_HINT ${BOOST_ROOT_HINTS})

--- a/dune/xt/grid/walker.hh
+++ b/dune/xt/grid/walker.hh
@@ -698,7 +698,6 @@ public:
   } // ... tbb_walk(...)
 #endif // HAVE_TBB
 
-private:
   template <class ElementRange>
   void walk_range(const ElementRange& element_range)
   {
@@ -736,6 +735,7 @@ private:
     } // .. walk elements
   } // ... walk_range(...)
 
+private:
   GridViewType grid_view_;
   // We want each thread to have its own copy of each functor. However, as we do not know in advance how many different
   // threads we will have (even if DXTC_CONFIG["threading.max_count"] is set, there may be only max_threads at a time,

--- a/dune/xt/la/container/eigen/base.hh
+++ b/dune/xt/la/container/eigen/base.hh
@@ -83,6 +83,8 @@ public:
 
   EigenBaseVector(EigenBaseVector&& source) = default;
 
+  using InterfaceType::operator=;
+
   VectorImpType& operator=(const ThisType& other)
   {
     if (this != &other) {

--- a/dune/xt/la/container/matrix-view.hh
+++ b/dune/xt/la/container/matrix-view.hh
@@ -321,7 +321,7 @@ public:
 
   ThisType& operator=(const Matrix& other)
   {
-    const auto& patt = const_matrix_view_.get_pattern();
+    const auto& patt = get_pattern();
     assert(pattern_assignable(other));
     for (size_t ii = 0; ii < rows(); ++ii)
       for (auto&& jj : patt.inner(ii))
@@ -351,7 +351,7 @@ public:
 
   inline void scal(const ScalarType& alpha)
   {
-    const auto& patt = const_matrix_view_.get_pattern();
+    const auto& patt = get_pattern();
     for (size_t ii = 0; ii < rows(); ++ii)
       for (auto&& jj : patt.inner(ii))
         set_entry(ii, jj, get_entry(ii, jj) * alpha);
@@ -361,7 +361,7 @@ public:
   {
     const auto other_patt = xx.pattern();
 #ifndef NDEBUG
-    const auto& patt = const_matrix_view_.get_pattern();
+    const auto& patt = get_pattern();
     if (xx.rows() != rows() || xx.cols() != cols())
       DUNE_THROW(Common::Exceptions::shapes_do_not_match, "Shapes do not match!");
     for (size_t ii = 0; ii < rows(); ++ii)
@@ -422,14 +422,14 @@ public:
 
   inline void clear_row(const size_t ii)
   {
-    const auto& patt = const_matrix_view_.get_pattern();
+    const auto& patt = get_pattern();
     for (auto&& jj : patt.inner(ii))
       set_entry(ii, jj, 0.);
   }
 
   inline void clear_col(const size_t jj)
   {
-    const auto& patt = const_matrix_view_.get_pattern();
+    const auto& patt = get_pattern();
     for (size_t ii = 0; ii < rows(); ++ii)
       if (std::find(patt.inner(ii).begin(), patt.inner(ii).end(), jj) != patt.inner(ii).end())
         set_entry(ii, jj, 0.);
@@ -452,10 +452,15 @@ public:
     return const_matrix_view_.operator Matrix();
   }
 
+  const SparsityPatternDefault& get_pattern() const
+  {
+    return const_matrix_view_.get_pattern();
+  }
+
 private:
   bool pattern_assignable(const Matrix& other) const
   {
-    const auto& patt = const_matrix_view_.get_pattern();
+    const auto& patt = get_pattern();
     const auto& other_patt = other.pattern();
     for (size_t ii = 0; ii < rows(); ++ii)
       for (auto&& jj : other_patt.inner(ii))

--- a/dune/xt/la/container/vector-interface.hh
+++ b/dune/xt/la/container/vector-interface.hh
@@ -462,6 +462,15 @@ public:
     return dot(other);
   }
 
+  template <class OtherTraits, class OtherScalarImp>
+  derived_type& operator=(const VectorInterface<OtherTraits, OtherScalarImp>& other)
+  {
+    for (size_t ii = 0; ii < size(); ++ii)
+      set_entry(ii, other.get_entry(ii));
+    return this->as_imp();
+  }
+
+
   /**
    *  \brief  Adds another vector to this, in-place variant.
    *  \param  other The second summand.
@@ -473,6 +482,14 @@ public:
     return this->as_imp();
   }
 
+  template <class OtherTraits, class OtherScalarImp>
+  derived_type& operator+=(const VectorInterface<OtherTraits, OtherScalarImp>& other)
+  {
+    for (size_t ii = 0; ii < size(); ++ii)
+      add_to_entry(ii, other.get_entry(ii));
+    return this->as_imp();
+  }
+
   /**
    *  \brief  Subtracts another vector from this, in-place variant.
    *  \param  other The subtrahend.
@@ -481,6 +498,14 @@ public:
   virtual derived_type& operator-=(const derived_type& other)
   {
     isub(other);
+    return this->as_imp();
+  }
+
+  template <class OtherTraits, class OtherScalarImp>
+  derived_type& operator-=(const VectorInterface<OtherTraits, OtherScalarImp>& other)
+  {
+    for (size_t ii = 0; ii < size(); ++ii)
+      add_to_entry(ii, -other.get_entry(ii));
     return this->as_imp();
   }
 


### PR DESCRIPTION
Sometimes, it is useful to walk over only a subset of entities, also in the non-parallel context. Includes changes from #23.