### PR TITLE
Update to 2.7 core modules

### DIFF
--- a/dune/xt/common/fvector.hh
+++ b/dune/xt/common/fvector.hh
@@ -148,7 +148,7 @@ public:
   }
 
   template <int R>
-  typename std::enable_if<SIZE != 1 && R == SIZE, K>::type operator*(const Dune::FieldMatrix<K, R, 1>& mat) const
+  typename std::enable_if<R == SIZE, K>::type operator*(const Dune::FieldMatrix<K, R, 1>& mat) const
   {
     K ret = 0;
     for (size_t ii = 0; ii < SIZE; ++ii)

--- a/dune/xt/common/parallel/helper.hh
+++ b/dune/xt/common/parallel/helper.hh
@@ -15,7 +15,7 @@
 #include <type_traits>
 #include <cassert>
 
-#include <dune/common/parallel/collectivecommunication.hh>
+#include <dune/common/parallel/communication.hh>
 
 #include <dune/istl/paamg/pinfo.hh>
 

--- a/dune/xt/grid/gridprovider/provider.hh
+++ b/dune/xt/grid/gridprovider/provider.hh
@@ -70,6 +70,10 @@ public:
     : grid_ptr_(grd_ptr)
   {}
 
+  GridProvider(Dune::ToUniquePtr<GridType> grd_ptr)
+    : grid_ptr_(std::shared_ptr<GridType>(grd_ptr))
+  {}
+
   GridProvider(const ThisType& other) = default;
 
   // Manual ctor required for clang 3.8.1-12~bpo8+1 (otherwise: undefined reference).

--- a/python/wrapper/dune_xt_execute.py
+++ b/python/wrapper/dune_xt_execute.py
@@ -27,7 +27,7 @@ from dune.testtools.parser import parse_ini_file
 
 def call(executable, inifile=None, *additional_args):
     # If we have an inifile, parse it and look for special keys that modify the execution
-    command = ["./" + executable]
+    command = [executable]
     if inifile:
         iniargument = inifile
         iniinfo = parse_ini_file(inifile)


### PR DESCRIPTION
This PR contains the necessary changes to support the DUNE core modules in version 2.7. All tests are compiling and passing locally.
Most changes are minor, so we could continue supporting DUNE 2.6 if necessary. The only significant change is in ``fmatrix.hh`` (because ``dune-common`` now supports several convenience operators like ``operator*(FieldMatrix, FieldMatrix)``), but we could just keep the old file as something like ``fmatrix-26.hh``, add the new version as ``fmatrix-27.hh`` and let ``fmatrix.hh`` decide which one to include based on the DUNE version.
However, from my side we could also simply drop support for DUNE 2.6 on master. Any opinions, @dune-community/dune-xt-devs?